### PR TITLE
fix: syntax error on ts 4.4.4 (CT-674)

### DIFF
--- a/src/DismissableLayerContext.tsx
+++ b/src/DismissableLayerContext.tsx
@@ -2,7 +2,8 @@ import React, { createContext, PropsWithChildren, ReactElement, useCallback, use
 
 import GlobalLayersContext from './GlobalLayersContext.js';
 import { useContextApi } from './hooks.js';
-import Subscriber, { type DismissEventType, DismissEventHandler } from './Subscriber.js';
+import Subscriber, { DismissEventHandler } from './Subscriber.js';
+import type { DismissEventType } from './Subscriber.js';
 
 interface DismissableLayerValue<T extends HTMLElement | Document = Document> {
   /**


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-674**

We are getting a build error on this:
```
[build:esm] yarn run build:esm exited with code 2
[build:cjs] ../../node_modules/react-dismissable-layers/lib/DismissableLayerContext.d.ts:2:27 - error TS1005: ',' expected.
[build:cjs] 
[build:cjs] 2 import Subscriber, { type DismissEventType, DismissEventHandler } from './Subscriber.js';
[build:cjs]                             ~~~~~~~~~~~~~~~~
[build:cjs] 
[build:cjs] 
[build:cjs] Found 1 error.
```